### PR TITLE
shrink the dhcpd pool size

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -253,7 +253,7 @@ dhcpd_servers:
       listen_ip: *core_network_01_tinc_ip
       domain_name: *zone_name
       nameservers: '169.254.0.1,169.254.0.2'
-      pool_range: '169.254.20.0 169.254.254.254'
+      pool_range: '169.254.100.1 169.254.100.254'
       secret: *bind_secret
       reverse_zone: *reverse_zone
       peer_address: *core_network_02_tinc_ip
@@ -271,7 +271,7 @@ dhcpd_servers:
       listen_ip: *core_network_02_tinc_ip
       domain_name: *zone_name
       nameservers: '169.254.0.1,169.254.0.2'
-      pool_range: '169.254.20.0 169.254.254.254' 
+      pool_range: '169.254.100.1 169.254.100.254' 
       secret: *bind_secret
       reverse_zone: *reverse_zone
       peer_address: *core_network_01_tinc_ip


### PR DESCRIPTION
The default setup is a vagrant setup, so we don't really need a dhcpd range of .x.x.
This PR limits the range to 254 nodes which will reduce the time it takes for the dhcpd service to start