### PR TITLE
5 move from active active to single dhcpd server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,8 @@ vagrant_acceptance_tests: ## runs acceptance tests on the 'laptop' box
 	vagrant ssh git2consul -- sudo systemctl status consul-client
 	vagrant ssh git2consul -- sudo systemctl status git2consul
 	vagrant ssh core01 -- sudo systemctl status isc-dhcp-server
-	vagrant ssh core02 -- sudo systemctl status isc-dhcp-server
+	vagrant ssh core01 -- sudo systemctl status bind9
+	vagrant ssh core02 -- sudo systemctl status bind9
 
 vagrant_reload: ## reloads all vagrant VMs
 	echo "running make vagrant_reload ..."

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -249,35 +249,14 @@ dhcpd_servers:
   servers: 
     node1: &dhcpdserver01
       <<: *dnsserver01
-      dhcpd_role: 'primary'
       listen_ip: *core_network_01_tinc_ip
       domain_name: *zone_name
       nameservers: '169.254.0.1,169.254.0.2'
       pool_range: '169.254.100.1 169.254.100.254'
       secret: *bind_secret
       reverse_zone: *reverse_zone
-      peer_address: *core_network_02_tinc_ip
       subnet: '169.254.0.0'
       netmask: '255.255.0.0'
-      failover_peer: 'tinc'
-      primary_ip: *core_network_01_tinc_ip
-      listen_interface: 'core-vpn'
-      ns1: *core_network_01_tinc_ip
-      ns2: *core_network_02_tinc_ip
-
-    node2: &dhcpdserver02
-      <<: *dnsserver02
-      dhcpd_role: 'secondary' 
-      listen_ip: *core_network_02_tinc_ip
-      domain_name: *zone_name
-      nameservers: '169.254.0.1,169.254.0.2'
-      pool_range: '169.254.100.1 169.254.100.254' 
-      secret: *bind_secret
-      reverse_zone: *reverse_zone
-      peer_address: *core_network_01_tinc_ip
-      subnet: '169.254.0.0'
-      netmask: '255.255.0.0'
-      failover_peer: 'tinc'
       primary_ip: *core_network_01_tinc_ip
       listen_interface: 'core-vpn'
       ns1: *core_network_01_tinc_ip

--- a/lib/clusters.py
+++ b/lib/clusters.py
@@ -221,17 +221,14 @@ class DHCPdCluster(object):
         for k_node, v_node in self.cfg['dhcpd_servers']['servers'].items():
             self.dhcpd_nodes.append(
                 lib.dhcpd.DHCPdServer(
-                    dhcpd_role=v_node['dhcpd_role'],
                     listen_ip=v_node['listen_ip'],
                     domain_name=v_node['domain_name'],
                     nameservers=v_node['nameservers'],
                     pool_range=v_node['pool_range'],
                     secret=v_node['secret'],
                     reverse_zone=v_node['reverse_zone'],
-                    peer_address=v_node['peer_address'],
                     subnet=v_node['subnet'],
                     netmask=v_node['netmask'],
-                    failover_peer=v_node['failover_peer'],
                     primary_ip=v_node['primary_ip'],
                     listen_interface=v_node['listen_interface'],
                     ssh_credentials=lib.host.SshCredentials(

--- a/lib/dhcpd.py
+++ b/lib/dhcpd.py
@@ -62,48 +62,40 @@ class DHCPdHost(lib.host.Host):
 class DHCPdServer(DHCPdHost):
     """ An object representing the DHCPd Server service """
     def __init__(self,
-                 dhcpd_role,
                  listen_ip,
                  domain_name,
                  nameservers,
                  pool_range,
                  secret,
                  reverse_zone,
-                 peer_address,
                  subnet,
                  netmask,
-                 failover_peer,
                  primary_ip,
                  listen_interface,
                  ssh_credentials):
         """ Generates a DHCPdServer object
 
         params:
-            string dhcpd_role: either primary or secondary
             string listen_ip: which IP should DHCPd listen on
             string domain_name: domain name for the DHCP pool
             string nameservers: nameservers to provide to the client
             string pool_range: ip range pool
             string secret: shared key between primary and secondary
             string reverse_zone: reverse_zone name
-            string peer_address: IP address of the peer dhcpd server
             string subnet: subnet to offer leases
             string netmask: netmask for offers
             string primary_ip: IP address of the DHCPd master
             string listen_interface: which interface to serve DHCP requests
             object ssh_credentials: ssh credentials to login to the host
         """
-        self.dhcpd_role = dhcpd_role
         self.listen_ip = listen_ip
         self.domain_name = domain_name
         self.nameservers = nameservers
         self.pool_range = pool_range
         self.secret = secret
         self.reverse_zone = reverse_zone
-        self.peer_address = peer_address
         self.subnet = subnet
         self.netmask = netmask
-        self.failover_peer = failover_peer
         self.primary_ip = primary_ip
         self.listen_interface = listen_interface
         self.ssh_credentials = ssh_credentials
@@ -127,17 +119,14 @@ class DHCPdServer(DHCPdHost):
                 use_sudo=True,
                 use_jinja=True,
                 context={
-                    'dhcpd_role': self.dhcpd_role,
                     'listen_ip': self.listen_ip,
                     'domain_name': self.domain_name,
                     'nameservers': self.nameservers,
                     'pool_range': self.pool_range,
                     'secret': self.secret,
                     'reverse_zone': self.reverse_zone,
-                    'peer_address': self.peer_address,
                     'subnet': self.subnet,
                     'netmask': self.netmask,
-                    'failover_peer': self.failover_peer,
                     'primary_ip': self.primary_ip,
                     'listen_interface': self.listen_interface
                 }

--- a/templates/dhcpd.conf.j2
+++ b/templates/dhcpd.conf.j2
@@ -2,20 +2,6 @@ authoritative;                                       # server is authoritative
 use-host-decl-names on;
 one-lease-per-client on;
 
-failover peer "{{ failover_peer }}" {               # fail over configuration
-         {{ dhcpd_role }};                                   # This is the primary
-         address {{ listen_ip }};                   # primarys ip address
-         port 647;
-         peer address {{ peer_address }};           # peer's ip address
-         peer port 647;
-         max-response-delay 60;
-         max-unacked-updates 10;
-         mclt 3600;
-{% if dhcpd_role == 'primary' %}
-         split 128;
-{% endif %}
-         load balance max seconds 3;
-}
 
 subnet {{ subnet }} netmask {{ netmask }}            # zone to issue addresses from
 {
@@ -25,7 +11,6 @@ subnet {{ subnet }} netmask {{ netmask }}            # zone to issue addresses f
         allow unknown-clients;
 
         pool {
-                failover peer "{{ failover_peer }}";           # pool for dhcp leases with failover bootp not allowed 
                 deny dynamic bootp clients;         
                 range {{ pool_range }};
                 max-lease-time 300;


### PR DESCRIPTION
drop the clustered failover dhcpd setup in favour of a single node 