### PR TITLE
Use class c network

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -20,7 +20,7 @@ ec2_common: &ec2_common
 
 tinc_common: &tinc_common
   env: 'development'
-  tinc_netmask: '255.255.0.0'
+  tinc_netmask: '255.255.255.0'
   tinc_network_name: 'core-vpn'
   tinc_network: '10.254.0.0'
 
@@ -150,7 +150,7 @@ roles:
 tinc_networks:
   core-vpn:
     tinc_network_name: &tinc_network_name 'core-vpn'
-    tinc_netmask: '255.255.0.0'
+    tinc_netmask: '255.255.255.0'
     tinc_network: '10.254.0.0'
     servers:
       core_network_01: *core_network_01
@@ -256,7 +256,7 @@ dhcpd_servers:
       secret: *bind_secret
       reverse_zone: *reverse_zone
       subnet: '10.254.0.0'
-      netmask: '255.255.0.0'
+      netmask: '255.255.255.0'
       primary_ip: *core_network_01_tinc_ip
       listen_interface: 'core-vpn'
       ns1: *core_network_01_tinc_ip

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -189,7 +189,7 @@ git2consul: &git2consul
   datacenter: 'tinc'
   version: '0.6.3'
   encrypt: *consul_encryption_key
-  tinc_ip: '10.254.0.10'
+  tinc_ip: '10.254.0.4'
   public_ip_address: '192.168.56.110'
   public_dns_name:  '192.168.56.110' # use ip address on vagrant
   tinc_private_key: <%= ENV['TINC_KEY_FILENAME_GIT2CONSUL'] %>
@@ -213,9 +213,9 @@ dnsserver_servers:
   zone_name: &zone_name 'tinc-core-vpn'
   reverse_zone: &reverse_zone '0.254.10.in-addr.arpa' 
   extra_zone_entries: &extra_zone_entries |
-    mesos-masters  IN      A     10.254.100.1 
-                   IN      A     10.254.100.2 
-                   IN      A     10.254.100.3 
+    mesos-masters  IN      A     10.254.0.11 
+                   IN      A     10.254.0.12 
+                   IN      A     10.254.0.13 
     *.service      IN      CNAME mesos-masters.tinc-core-vpn.
   servers: 
     node1: &dnsserver01
@@ -252,7 +252,7 @@ dhcpd_servers:
       listen_ip: *core_network_01_tinc_ip
       domain_name: *zone_name
       nameservers: '10.254.0.1,10.254.0.2'
-      pool_range: '10.254.100.1 10.254.100.254'
+      pool_range: '10.254.0.10 10.254.0.254'
       secret: *bind_secret
       reverse_zone: *reverse_zone
       subnet: '10.254.0.0'

--- a/laptop/etc/tinc/core-vpn/fix-route
+++ b/laptop/etc/tinc/core-vpn/fix-route
@@ -7,5 +7,5 @@ netstat -rnv | grep 10.254.0.0 | grep 0.0.0.0 >/dev/null 2>&1
 if [ $? = 0 ]; then
   # TODO: we're assuming a 10.254.0.0 block here, fix it
   route del -net 10.254.0.0 netmask 255.255.255.0 gateway 0.0.0.0
-  route add -net 10.254.0.0 netmask 255.255.255.0 gateway `ifconfig tinc.core-vpn| grep inet | awk '{ print $2 }' `
+  route add -net 10.254.0.0 netmask 255.255.255.0 gateway `ifconfig core-vpn| grep inet | awk '{ print $2 }' | cut -f 2 -d ':' `
 fi

--- a/laptop/etc/tinc/core-vpn/fix-route
+++ b/laptop/etc/tinc/core-vpn/fix-route
@@ -6,6 +6,6 @@ netstat -rnv | grep 10.254.0.0 | grep 0.0.0.0 >/dev/null 2>&1
 
 if [ $? = 0 ]; then
   # TODO: we're assuming a 10.254.0.0 block here, fix it
-  route del -net 10.254.0.0 netmask 255.255.0.0 gateway 0.0.0.0
-  route add -net 10.254.0.0 netmask 255.255.0.0 gateway `ifconfig tinc.core-vpn| grep inet | awk '{ print $2 }' `
+  route del -net 10.254.0.0 netmask 255.255.255.0 gateway 0.0.0.0
+  route add -net 10.254.0.0 netmask 255.255.255.0 gateway `ifconfig tinc.core-vpn| grep inet | awk '{ print $2 }' `
 fi

--- a/tasks/fabfile.py
+++ b/tasks/fabfile.py
@@ -532,7 +532,7 @@ def vagrant_test_cycle():
     sleep(180) # give enough time for DHCP do its business
     execute(vagrant_up_laptop)
     execute(acceptance_tests)
-    sleep(300) # give enough time for the laptop to do its business
+    sleep(360) # give enough time for the laptop to do its business
     execute(vagrant_acceptance_tests)
 
 @task

--- a/tasks/fabfile.py
+++ b/tasks/fabfile.py
@@ -492,6 +492,13 @@ def vagrant_up_laptop():
 @retry(stop_max_attempt_number=3, wait_fixed=30000)
 def vagrant_acceptance_tests():
     log_green('running vagrant_acceptance_tests')
+
+    log_green('restarting tincd to obtain an ip address')
+    local('vagrant ssh laptop -- sudo systemctl restart tinc', capture=True)
+
+    log_green('waiting 90sec for an ip address')
+    sleep(90) 
+
     for ip in ['10.254.0.1', '10.254.0.2', '10.254.0.3', '10.254.0.10']:
         local('vagrant ssh laptop -- ping -c 1 -w 20 %s' %ip, capture=True)
 

--- a/templates/dhcpd.conf.j2
+++ b/templates/dhcpd.conf.j2
@@ -7,7 +7,7 @@ subnet {{ subnet }} netmask {{ netmask }}            # zone to issue addresses f
 {
         option domain-name "{{ domain_name }}.";              # the domain name issued
         option domain-name-servers {{ nameservers }};        # name servers issued
-        option subnet-mask 255.255.0.0;
+        option subnet-mask 255.255.255.0;
         allow unknown-clients;
 
         pool {


### PR DESCRIPTION
switch to a class C network, as it will speed up the DHCP boot up (needed to bring back the DCHP failover).
Also fixes an issue on the vagrant_acceptance_tests that was causing the 'ping' test from the laptop to fail, due to a missing route.

two green builds