### PR TITLE
Revert "re-enable host io cache"

### DIFF
--- a/Vagrantfile.core01
+++ b/Vagrantfile.core01
@@ -18,10 +18,11 @@ Vagrant.configure("2") do |config|
       v.customize ["modifyvm", :id, "--natdnsproxy1", "off"]
       v.customize ["modifyvm", :id, "--natdnshostresolver1", "off"]
       Vagrant::Util::Platform.linux? and v.customize ["modifyvm", :id, "--paravirtprovider", "kvm"]
+      # https://forums.virtualbox.org/viewtopic.php?f=20&t=45245
       v.customize [
         "storagectl", :id, 
         "--name", "SATA Controller",
-        "--hostiocache", "on"
+        "--hostiocache", "off"
       ]
     end
   end

--- a/Vagrantfile.core02
+++ b/Vagrantfile.core02
@@ -24,7 +24,7 @@ Vagrant.configure("2") do |config|
       v.customize [
         "storagectl", :id, 
         "--name", "SATA Controller",
-        "--hostiocache", "on"
+        "--hostiocache", "off"
       ]
     end
   end

--- a/Vagrantfile.core03
+++ b/Vagrantfile.core03
@@ -24,7 +24,7 @@ Vagrant.configure("2") do |config|
       v.customize [
         "storagectl", :id, 
         "--name", "SATA Controller",
-        "--hostiocache", "on"
+        "--hostiocache", "off"
       ]
     end
   end

--- a/Vagrantfile.git2consul
+++ b/Vagrantfile.git2consul
@@ -1,3 +1,5 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
 
 UPSTREAM_VM_BOX = 'bento/ubuntu-16.04'
 
@@ -23,7 +25,7 @@ Vagrant.configure("2") do |config|
       v.customize [
         "storagectl", :id, 
         "--name", "SATA Controller",
-        "--hostiocache", "on"
+        "--hostiocache", "off"
       ]
     end
   end

--- a/Vagrantfile.laptop
+++ b/Vagrantfile.laptop
@@ -24,7 +24,7 @@ Vagrant.configure("2") do |config|
       v.customize [
         "storagectl", :id, 
         "--name", "SATA Controller",
-        "--hostiocache", "on"
+        "--hostiocache", "off"
       ]
     end
 


### PR DESCRIPTION
Reverts JeevesTakesOver/Railtrack#31

running Railtrack on a busy system will trigger IO errors, so reverting this.